### PR TITLE
Add siglensent chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,27 @@ siglens:
   configs:
     license: abc.txt
 ```
+
+# Siglensent
+## Installation
+Create a custom-values.yaml file where you'll supply your license and other
+configurations. By default the chart installs into the `siglens` namespace;
+you can change this in your custom-values.yaml, or you can first create that
+namespace with `kubectl create namespace siglens`. Then install with:
+```
+helm repo add siglens-repo https://siglens.github.io/charts
+helm install siglensent siglens-repo/siglensent -f custom-values.yaml --namespace siglens
+```
+
+If TLS is enabled, you'll need to update your DNS to point to the ingress
+controller. You can find the load balancer with:
+```
+kubectl get svc --all-namespaces
+```
+Look for the service with the `ingress-nginx-controller` name in the namespace
+you installed into. Then make a CNAME record in your DNS to point to the load
+balancer.
+
+**Note:** If you uninstall and reinstall the chart, you'll need to update your
+DNS again. But if you do a `helm upgrade` instead, the ingress controller will
+persist, so you won't have to update your DNS.

--- a/charts/siglensent/.helmignore
+++ b/charts/siglensent/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/siglensent/Chart.lock
+++ b/charts/siglensent/Chart.lock
@@ -1,0 +1,12 @@
+dependencies:
+- name: ingress-nginx
+  repository: https://kubernetes.github.io/ingress-nginx
+  version: 4.10.0
+- name: cert-manager
+  repository: https://charts.jetstack.io
+  version: v1.14.4
+- name: etcd
+  repository: https://charts.bitnami.com/bitnami
+  version: 10.0.3
+digest: sha256:a790c866e547d9ee35a4301b9d873a78997d02c9e7a8e78d88f8678533f96c17
+generated: "2024-04-11T14:41:50.685814-06:00"

--- a/charts/siglensent/Chart.yaml
+++ b/charts/siglensent/Chart.yaml
@@ -1,0 +1,28 @@
+apiVersion: v2
+name: siglensent
+description: A Helm chart for Kubernetes
+
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.1.35d"
+
+dependencies:
+  - name: ingress-nginx
+    version: "4.10.0"
+    repository: https://kubernetes.github.io/ingress-nginx
+  - name: cert-manager
+    version: "1.14.4"
+    repository: https://charts.jetstack.io
+  - name: etcd
+    version: "10.0.3"
+    repository: https://charts.bitnami.com/bitnami
+    condition: multinode.enabled

--- a/charts/siglensent/templates/cert-issuer.yaml
+++ b/charts/siglensent/templates/cert-issuer.yaml
@@ -1,0 +1,23 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: letsencrypt
+spec:
+  acme:
+    # The ACME server URL
+    {{- if .Values.acme.useProductionCertificate }}
+    server: https://acme-v02.api.letsencrypt.org/directory
+    {{- else }}
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    {{- end }}
+    # Email address used for ACME registration
+    email: {{ .Values.acme.registrationEmail }}
+    # Name of a secret used to store the ACME account private key
+    privateKeySecretRef:
+      name: letsencrypt-secret
+    # Enable the HTTP-01 challenge provider
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: nginx
+

--- a/charts/siglensent/templates/configmaps.yaml
+++ b/charts/siglensent/templates/configmaps.yaml
@@ -1,0 +1,61 @@
+{{- define "siglens.configmap" -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .name }}
+  namespace: {{ .namespace }}
+data:
+  server.yaml: |-
+    {{- .config | toYaml | nindent 4 }}
+    ingestNode: {{ .isIngestNode }}
+    queryNode: {{ .isQueryNode }}
+    etcd:
+      enabled: {{ .multinode.enabled }}
+      username: {{ .siglensEtcd.username }}
+      password: {{ .siglensEtcd.password | default .etcdRootPassword }}
+      seedUrls:
+        - {{ printf "http://%s-etcd.%s.svc.cluster.local:2379" .Release.Name .namespace }}
+{{- end -}}
+
+{{- if .Values.multinode.enabled }}
+  {{- $ingestConfigmap := dict
+    "Release" .Release
+    "multinode" .Values.multinode
+    "name" (printf "%s-ingest-configmap" .Release.Name)
+    "namespace" .Values.namespace
+    "config" .Values.config
+    "siglensEtcd" .Values.siglensEtcdOverrides
+    "etcdRootPassword" .Values.etcd.auth.rbac.rootPassword
+    "isIngestNode" true
+    "isQueryNode" (not .Values.multinode.enabled)
+  }}
+  {{- $queryConfigmap := dict
+    "Release" .Release
+    "multinode" .Values.multinode
+    "name" (printf "%s-query-configmap" .Release.Name)
+    "namespace" .Values.namespace
+    "config" .Values.config
+    "siglensEtcd" .Values.siglensEtcdOverrides
+    "etcdRootPassword" .Values.etcd.auth.rbac.rootPassword
+    "isIngestNode" (not .Values.multinode.enabled)
+    "isQueryNode" true
+  }}
+
+  {{- include "siglens.configmap" $ingestConfigmap -}}
+  {{ printf "\n---\n" }}
+  {{- include "siglens.configmap" $queryConfigmap -}}
+{{ else }}
+  {{- $configmap := dict
+    "Release" .Release
+    "multinode" .Values.multinode
+    "name" (printf "%s-%s" .Release.Name "ingest-and-query-configmap")
+    "namespace" .Values.namespace
+    "config" .Values.config
+    "siglensEtcd" .Values.siglensEtcdOverrides
+    "etcdRootPassword" .Values.etcd.auth.rbac.rootPassword
+    "isIngestNode" true
+    "isQueryNode" true
+  }}
+
+  {{- include "siglens.configmap" $configmap -}}
+{{- end -}}

--- a/charts/siglensent/templates/deployments.yaml
+++ b/charts/siglensent/templates/deployments.yaml
@@ -1,0 +1,117 @@
+{{- define "siglens.deployment" -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-{{ .appName }}-deployment
+  namespace: {{ .namespace }}
+spec:
+  replicas: {{ .numReplicas }}
+  selector:
+    matchLabels:
+      app: {{ .appName }}
+  template:
+    metadata:
+      labels:
+        app: {{ .appName }}
+    spec:
+      serviceAccountName: {{ .serviceAccountName }}
+      initContainers:
+      - name: volume-permissions
+        image: busybox
+        # Set ownership of the /siglens/data directory. This is where EBS is
+        # mounted and where siglens stores the ingested data. Without setting
+        # ownership here, the pod fails to start up because it doesn't have
+        # permissions to make subdirectories of /siglens/data.
+        command: ['sh', '-c', 'chown -R 1000:1000 /siglens/data']
+        volumeMounts:
+        - name: data-volume
+          mountPath: /siglens/data
+      {{- if .imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ .imagePullSecret }}
+      {{- end }}
+      containers:
+      - name: {{ .appName}}-container
+        image: {{ .image }}
+        imagePullPolicy: {{ .imagePullPolicy }}
+        {{- if .enterprise }}
+        command: ["./sigscalr"]
+        {{ else }}
+        command: ["./siglens"]
+        {{- end }}
+        args: ["--config", "/config/server.yaml"]
+        ports:
+        {{- range .ports }}
+        - containerPort: {{ . }}
+        {{- end }}
+        volumeMounts:
+        - mountPath: /siglens/data # The docker image specifies siglens/ as the workdir
+          name: data-volume
+        - mountPath: /config
+          name: {{ .appName }}-config
+        - mountPath: /license
+          name: license-volume
+        - mountPath: /certs
+          name: cert-volume
+      volumes:
+      - name: data-volume
+        persistentVolumeClaim:
+          claimName: ebs-pvc
+      - name: {{ .appName }}-config
+        configMap:
+          name: {{ .Release.Name}}-{{ .appName }}-configmap
+      - name: license-volume
+        secret:
+          secretName: {{ $.Release.Name }}-license-secret
+          items:
+          - key: license
+            path: license.txt
+      - name: cert-volume
+        secret:
+          secretName: ingress-tls
+{{- end -}}
+
+{{ if .Values.multinode.enabled }}
+  {{- $ingestDeployment := dict
+    "Release"         .Release
+    "namespace"       .Values.namespace
+    "appName"         "ingest"
+    "ports"           (list .Values.config.ingestPort)
+    "numReplicas"     .Values.multinode.ingestReplicas
+    "serviceAccountName" ( printf "%s-%s" .Release.Name "service-account" )
+    "image"           .Values.image
+    "imagePullPolicy" .Values.imagePullPolicy
+    "imagePullSecret" ( eq "" .Values.dockerConfigBase64 | ternary "" (printf "%s-registry-secret" .Release.Name) )
+    "enterprise"      .Values.enterprise
+  }}
+  {{- $queryDeployment := dict
+    "Release"         .Release
+    "namespace"       .Values.namespace
+    "appName"         "query"
+    "ports"           (list .Values.config.queryPort)
+    "numReplicas"     .Values.multinode.queryReplicas
+    "serviceAccountName" ( printf "%s-%s" .Release.Name "service-account" )
+    "image"           .Values.image
+    "imagePullPolicy" .Values.imagePullPolicy
+    "imagePullSecret" ( eq "" .Values.dockerConfigBase64 | ternary "" (printf "%s-registry-secret" .Release.Name) )
+    "enterprise"      .Values.enterprise
+  }}
+
+  {{ include "siglens.deployment" $ingestDeployment | indent 0 }}
+  {{ printf "\n---\n" }}
+  {{ include "siglens.deployment" $queryDeployment | indent 0 }}
+{{ else }}
+  {{- $deployment := dict
+    "Release"         .Release
+    "namespace"       .Values.namespace
+    "appName"         "ingest-and-query"
+    "ports"           (list .Values.config.ingestPort .Values.config.queryPort)
+    "numReplicas"     1
+    "serviceAccountName" ( printf "%s-%s" .Release.Name "service-account" )
+    "image"           .Values.image
+    "imagePullPolicy" .Values.imagePullPolicy
+    "imagePullSecret" ( eq "" .Values.dockerConfigBase64 | ternary "" (printf "%s-registry-secret" .Release.Name) )
+    "enterprise"      .Values.enterprise
+  }}
+  {{- include "siglens.deployment" $deployment -}}
+{{ end }}

--- a/charts/siglensent/templates/image-registry-secret.yaml
+++ b/charts/siglensent/templates/image-registry-secret.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.dockerConfigBase64 }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-registry-secret
+  namespace: {{ .Values.namespace }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ .Values.dockerConfigBase64 }}
+{{- end }}

--- a/charts/siglensent/templates/ingress.yaml
+++ b/charts/siglensent/templates/ingress.yaml
@@ -1,0 +1,37 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress
+  namespace: {{ .Values.namespace }}
+  annotations:
+    cert-manager.io/issuer: "letsencrypt"
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+spec:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - {{ .Values.queryHost }}
+    - {{ .Values.ingestHost }}
+    secretName: ingress-tls
+  rules:
+  - host: {{ .Values.queryHost }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .Release.Name }}-query-service
+            port:
+              number: {{ .Values.config.queryPort }}
+  - host: {{ .Values.ingestHost }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .Release.Name }}-ingest-service
+            port:
+              number: {{ .Values.config.ingestPort }}

--- a/charts/siglensent/templates/license-secret.yaml
+++ b/charts/siglensent/templates/license-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name}}-license-secret
+  namespace: {{ .Values.namespace }}
+type: Opaque
+data:
+  license: {{ .Values.licenseBase64 }}

--- a/charts/siglensent/templates/persistent-volume-claims.yaml
+++ b/charts/siglensent/templates/persistent-volume-claims.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ebs-pvc
+  namespace: {{ .Values.namespace }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ebs-sc
+  resources:
+    requests:
+      storage: {{ .Values.ebs.storageSize }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: efs-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: efs-sc
+  resources:
+    requests:
+      storage: {{ .Values.ebs.storageSize }}
+

--- a/charts/siglensent/templates/service-account.yaml
+++ b/charts/siglensent/templates/service-account.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-service-account
+  namespace: {{ .Values.namespace }}
+  annotations:
+    {{- range $key, $value := .Values.serviceAccountAnnotations }}
+    {{ $key }}: {{ $value }}
+    {{- end }}

--- a/charts/siglensent/templates/services.yaml
+++ b/charts/siglensent/templates/services.yaml
@@ -1,0 +1,32 @@
+{{- define "siglens.service" }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .name }}
+  namespace: {{ .namespace }}
+spec:
+  type: NodePort
+  selector:
+    app: {{ .appName }}
+  ports:
+    - protocol: TCP
+      port: {{ .port }}
+      targetPort: {{ .port }}
+{{- end }}
+
+{{- $ingestService := dict
+  "name"      (printf "%s-ingest-service" .Release.Name)
+  "namespace" .Values.namespace
+  "appName"   (.Values.multinode.enabled | ternary "ingest" "ingest-and-query")
+  "port"      .Values.config.ingestPort
+}}
+{{- $queryService := dict
+  "name"      (printf "%s-query-service" .Release.Name)
+  "namespace" .Values.namespace
+  "appName"   (.Values.multinode.enabled | ternary "query" "ingest-and-query")
+  "port"      .Values.config.queryPort
+}}
+
+{{ include "siglens.service" $ingestService }}
+---
+{{ include "siglens.service" $queryService }}

--- a/charts/siglensent/templates/storage-classes.yaml
+++ b/charts/siglensent/templates/storage-classes.yaml
@@ -1,0 +1,22 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ebs-sc
+provisioner: ebs.csi.aws.com
+parameters:
+  type: gp2
+reclaimPolicy: Retain
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: efs-sc
+provisioner: efs.csi.aws.com
+reclaimPolicy: Retain
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  provisioningMode: efs-ap
+  fileSystemId: {{ .Values.efs.fileSystemId }}

--- a/charts/siglensent/values.yaml
+++ b/charts/siglensent/values.yaml
@@ -1,0 +1,97 @@
+namespace: siglens
+
+# Overrides for the ingress-nginx subchart.
+ingress-nginx:
+  namespaceOverride: siglens
+
+# Overrides for the cert-manager subchart.
+cert-manager:
+  namespace: siglens
+
+# Overrides for the etcd subchart.
+etcd:
+  namespace: siglens
+  replicaCount: 3
+  auth:
+    rbac:
+      rootPassword: dontkeepthispassword
+
+# Used for pulling the SigLens image from a private registry. Not needed for
+# public registries. If you're using a private registry, set this to the output
+# of `cat ~/.docker/config.json | base64`.
+dockerConfigBase64: ""
+
+image: 123456789012.dkr.ecr.us-east-1.amazonaws.com/siglens:latest
+imagePullPolicy: Always
+
+# If you're using an enterprise image, set "enterprise" to true. Enterprise
+# images require a license. To specify your license, set "licenseBase64" to the
+# output of `cat /path/to/licenseKey.txt | base64`.
+enterprise: false
+licenseBase64: ""
+
+# Multinode sets up multiple ingest and query nodes. This is only available for
+# enterprise setups. Withoutu multinode, there will be just one pod, which
+# handles both ingest and query.
+multinode:
+  enabled: false
+  ingestReplicas: 2
+  queryReplicas: 2
+
+# For multinode, these are the credentials pods will use to connect to etcd.
+siglensEtcdOverrides:
+  username: root
+  password: "" # If empty, will use etcd.auth.rbac.rootPassword
+
+# If TLS is enabled, these settings are used to gererate a certificate.
+acme:
+  useProductionCertificate: true
+  registrationEmail: "you@example.com"
+
+queryHost: "siglens.example.com"
+ingestHost: "ingest.siglens.example.com"
+
+ebs: # Used for sharing data between pods on the same node.
+  storageSize: 20Gi
+
+efs: # Used for etcd data storage in a multinode setup.
+  fileSystemId: "fs-1234567890abcdef1"
+  storageSize: 20Gi
+
+# Annotations for pod privileges. Needed for setups with S3 (which is required
+# for multinode) so the pods can read and write to S3.
+serviceAccountAnnotations:
+  # Example:
+  # eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/YourRole
+
+# You can add other configs here that siglens supports (e.g., from your
+# server.yaml used to run siglens locally)
+#
+# Note: Don't include any of the following keys even though you may have them
+# in your server.yaml; they are already set by the Helm chart if needed:
+# - isIngestNode
+# - isQueryNode
+# - etcd
+config:
+  tls:
+    enabled: true
+    certificatePath: /certs/tls.crt
+    privateKeyPath: /certs/tls.key
+
+  # Address port for SigLens ingestion server
+  ingestPort: 8081
+
+  # Address port for SigLens query server, including UI
+  queryPort: 5122
+
+  # Location for storing local node data
+  dataPath : data/
+
+  # field name to use as a timestamp key
+  timestampKey : timestamp
+
+  # Where the license is stored within the container
+  licenseKeyPath: /license/license.txt
+
+  # For ephemeral servers (docker, k8s) set this variable to unique container name to persist data across restarts
+  ssInstanceName: "siglens-pod"


### PR DESCRIPTION
Adds the siglensent chart, which can run siglens enterprise with multinode and automatically setup TLS and the etcd cluster. This requires using an enterprise image and supplying your license credentials.

This also currently assumes AWS is the cloud provider (for things like filesystems and long term storage). Later we should add support for others.