### PR TITLE
Add dependency charts before doing chart releaser

### DIFF
--- a/.github/workflows/chart-releaser.yaml
+++ b/.github/workflows/chart-releaser.yaml
@@ -27,6 +27,11 @@ jobs:
         uses: azure/setup-helm@v1
         with:
           version: v3.8.1
+      - name: Add dependency repositories
+        run: |
+          for dir in $(ls -d charts/*/); do
+            helm dependency list $dir 2> /dev/null | tail +2 | head -n -1 | awk '{ print "helm repo add " $1 " " $3 }' | while read cmd; do $cmd; done
+          done
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.4.0
         env:


### PR DESCRIPTION
This makes sure that helm has access to all the dependencies it needs to release each chart before it actually tries to release the charts.

Credit: https://github.com/helm/chart-releaser-action/issues/74#issuecomment-1206111172