### PR TITLE
Fix OTEL logging config

### DIFF
--- a/charts/siglens/templates/otel-collector.yaml
+++ b/charts/siglens/templates/otel-collector.yaml
@@ -67,8 +67,8 @@ data:
     processors:
       batch:
     exporters:
-      logging:
-        loglevel: debug
+      debug:
+        verbosity: detailed
       prometheusremotewrite:
         endpoint: 'http://{{ include "siglens.fullname" . }}-ingest-svc:{{ .Values.siglens.configs.ingestPort }}/promql/api/v1/write'
     service:


### PR DESCRIPTION
Some OTEL config got deprecated. See [the announcement](https://github.com/open-telemetry/opentelemetry-collector/issues/11337).

Due to this deprecation, the otel collector pod wasn't starting properly when installing the helm chart.