### PR TITLE
Increase termination timeout to 5 minutes

### DIFF
--- a/charts/siglensent/templates/worker-deployment.yaml
+++ b/charts/siglensent/templates/worker-deployment.yaml
@@ -24,6 +24,7 @@ spec:
       annotations:
         checksum/config: sha256-checksum-placeholder
     spec:
+      terminationGracePeriodSeconds: 300
       serviceAccountName: {{ .Release.Name }}-service-account
       initContainers:
       - name: volume-permissions


### PR DESCRIPTION
Increases the graceful termination timeout from the default of 30 seconds. Kubernetes will forcibly kill the pod after the termination period.

Note: I thought we could use a `PreStop` hook to wait indefinitely for the hook to finish to ensure graceful shutdown, but in fact Kubernetes would still interrupt the hook with a SIGKILL if it takes too long (see https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination)