### PR TITLE
Make TLS and busybox more configurable

### DIFF
--- a/charts/siglensent/Chart.yaml
+++ b/charts/siglensent/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.24
+version: 0.1.25
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/siglensent/templates/ingress.yaml
+++ b/charts/siglensent/templates/ingress.yaml
@@ -4,18 +4,22 @@ metadata:
   name: ingress
   namespace: {{ .Values.global.namespace }}
   annotations:
-    cert-manager.io/issuer: "letsencrypt"
-    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-    nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+    {{- if and .Values.config.tls.enabled .Values.ingress.certManagerIssuer }}
+    cert-manager.io/issuer: "{{ .Values.ingress.certManagerIssuer }}"
+    {{- end }}
+    {{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key }}: "{{ $value }}"
+    {{- end }}
 spec:
   ingressClassName: nginx
+  {{- if .Values.config.tls.enabled }}
   tls:
   - hosts:
     - {{ .Values.queryHost }}
     - {{ .Values.ingestHost }}
     - {{ .Values.managementHost }}
     secretName: {{ .Values.ingress.tlsSecret }}
+  {{- end }}
   rules:
   - host: {{ .Values.queryHost }}
     http:

--- a/charts/siglensent/templates/raft-deployment.yaml
+++ b/charts/siglensent/templates/raft-deployment.yaml
@@ -28,7 +28,8 @@ spec:
       serviceAccountName: {{ .Release.Name }}-service-account
       initContainers:
       - name: volume-permissions
-        image: busybox
+        image: {{ .Values.initContainer.image }}
+        imagePullPolicy: {{ .Values.initContainer.imagePullPolicy }}
         command: ['sh', '-c', 'chown -R 1000:1000 /siglens/data']
         volumeMounts:
         - name: data-volume

--- a/charts/siglensent/templates/worker-deployment.yaml
+++ b/charts/siglensent/templates/worker-deployment.yaml
@@ -34,7 +34,8 @@ spec:
       serviceAccountName: {{ .Release.Name }}-service-account
       initContainers:
       - name: volume-permissions
-        image: busybox
+        image: {{ .Values.initContainer.image }}
+        imagePullPolicy: {{ .Values.initContainer.imagePullPolicy }}
         command:
           - 'sh'
           - '-c'

--- a/charts/siglensent/values.yaml
+++ b/charts/siglensent/values.yaml
@@ -212,3 +212,7 @@ registry:
   dockerConfigBase64: ""
   image: ghcr.io/sigscalr/hyperion:v1.0.31-ent1
   imagePullPolicy: Always
+
+initContainer:
+  image: busybox:1.36.1
+  imagePullPolicy: IfNotPresent

--- a/charts/siglensent/values.yaml
+++ b/charts/siglensent/values.yaml
@@ -67,8 +67,15 @@ managementService:
 
 ingress:
   tlsSecret: ingress-tls
+  # Set to empty string or different issuer name to use custom cert manager
+  certManagerIssuer: "letsencrypt"
+  # Custom annotations for the ingress
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/proxy-body-size: "50m"
 
-# If TLS is enabled, these settings are used to gererate a certificate.
+# If TLS is enabled, these settings are used to generate a certificate.
 acme:
   useProductionCertificate: true
   registrationEmail: "you@example.com"


### PR DESCRIPTION
# Description
1. Pin the busybox image by default, and make it configurable
2. Allow custom TLS annotations

# Testing
I haven't installed the updated chart, but `helm lint` passes, and diffing the rendered chart with `helm template test-release .` before and after this PR gives this with the default values.yaml:
```diff
diff --git a/deleteme/main b/deleteme/tls
index 9bf16e4..9c49daf 100644
--- a/deleteme/main
+++ b/deleteme/tls
@@ -1795,7 +1795,8 @@ spec:
       serviceAccountName: test-release-service-account
       initContainers:
       - name: volume-permissions
-        image: busybox
+        image: busybox:1.36.1
+        imagePullPolicy: IfNotPresent
         command: ['sh', '-c', 'chown -R 1000:1000 /siglens/data']
         volumeMounts:
         - name: data-volume
@@ -1880,7 +1881,8 @@ spec:
       serviceAccountName: test-release-service-account
       initContainers:
       - name: volume-permissions
-        image: busybox
+        image: busybox:1.36.1
+        imagePullPolicy: IfNotPresent
         command:
           - 'sh'
           - '-c'
@@ -1977,9 +1979,9 @@ metadata:
   namespace: siglensent
   annotations:
     cert-manager.io/issuer: "letsencrypt"
-    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
 spec:
   ingressClassName: nginx
   tls:
```